### PR TITLE
Follow `android_logger` API change.

### DIFF
--- a/v0.13/src/lib.rs
+++ b/v0.13/src/lib.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use android_logger::Config;
-use log::{debug, Level, log};
+use log::{debug, LevelFilter, log};
 use wgpu::{ColorTargetState, ColorWrites, PresentMode, SurfaceConfiguration, TextureViewDescriptor};
 use winit::{
     event::{Event, WindowEvent},
@@ -179,7 +179,7 @@ ndk_glue::main(backtrace = "on", logger(level = "debug", tag = "wgpu"))
 )]
 fn main() {
     android_logger::init_once(
-        Config::default().with_min_level(Level::Trace),
+        Config::default().with_max_level(LevelFilter::Trace),
     );
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop).unwrap();


### PR DESCRIPTION
An alternative to https://github.com/andraantariksa/wgpu-winit-android-example/pull/1.